### PR TITLE
Expose TruthTable.Env to the elm package manager

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -8,6 +8,7 @@
     ],
     "exposed-modules": [
         "TruthTable",
+        "TruthTable.Env",
         "TruthTable.Expr"
     ],
     "dependencies": {


### PR DESCRIPTION
Hey, I noticed no way to construct an Env through the docs, this should fix it!